### PR TITLE
chore: Refactor parse_output function to handle newline addition for …

### DIFF
--- a/libs/partners/upstage/tests/unit_tests/test_layout_analysis.py
+++ b/libs/partners/upstage/tests/unit_tests/test_layout_analysis.py
@@ -153,7 +153,9 @@ def test_none_split_html_output(mock_post: Mock) -> None:
     documents = loader.load()
 
     assert len(documents) == 1
-    assert documents[0].page_content == MOCK_RESPONSE_JSON["html"]
+    assert documents[0].page_content == "\n".join(
+        [element["html"] for element in MOCK_RESPONSE_JSON["elements"]]
+    )
     assert documents[0].metadata["total_pages"] == 1
     assert documents[0].metadata["type"] == "html"
     assert documents[0].metadata["split"] == "none"
@@ -201,7 +203,9 @@ def test_page_split_html_output(mock_post: Mock) -> None:
 
     assert len(documents) == 1
 
-    for i, document in enumerate(documents):
-        assert document.metadata["page"] == MOCK_RESPONSE_JSON["elements"][i]["page"]
-        assert document.metadata["type"] == "html"
-        assert document.metadata["split"] == "page"
+    assert documents[0].page_content == "\n ".join(
+        [element["html"] for element in MOCK_RESPONSE_JSON["elements"]]
+    )
+    assert documents[0].metadata["page"] == MOCK_RESPONSE_JSON["elements"][0]["page"]
+    assert documents[0].metadata["type"] == "html"
+    assert documents[0].metadata["split"] == "page"


### PR DESCRIPTION
- 관련 스레드 : https://upstageai.slack.com/archives/C06T3A3BMR7/p1715381813783559
- parse_output 함수에서 output_type이 html인 경우에만 개행을 붙입니다
  - parse_output 함수는 api 에서 받아온 element 결과를 파싱하는 함수입니다
  - 이 함수의 결과를 받아와 element에서는 바로 쓰고, page, none에서는 붙여서 씁니다
- Document로 출력값을 생성할 때는 page_content의 값을 strip해서 마지막에 개행이 붙는 것을 방지합니다
- output_type이 dict일때는 recursive로 parse_output 함수를 실행하도록 수정했습니다
- unit test도 수정해서 돌아가는 것을 확인했습니다